### PR TITLE
Support fo unicode and octal escapes in string literals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ instances of `true` yield that (identical) value, and similarly for `false`.
 ### strings
 
 Strings are enclosed in `"double quotes"`. May span multiple lines. Standard C/Java escape
-characters `\t, \r, \n, \\ and \"` are supported.
+characters `\t, \r, \n, \\ and \"` are supported. Unicode escapes \uNNNN and octal escapes \0 to \377 are also supported, as in Java.
 
 ### characters
 


### PR DESCRIPTION
Specs do not mention whether unicode and octal escapes are supported or not. As clojure.edn supports it [1], I've added an explicit mention in the specs. I'm a registered clojure contributor (signed CA).

[1] https://github.com/clojure/clojure/blob/c6756a8bab137128c8119add29a25b0a88509900/src/jvm/clojure/lang/EdnReader.java#L580
