### PR TITLE
allow floats to end in point, like clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ valid integer not distinct from 0.
       - digit
       - 1-9 digits
     frac
+      .
       . digits
     exp
       ex digits


### PR DESCRIPTION
This spec is currently at odds with the de facto spec that is the clojure implementation, in not allowing `1.` as a floating point number.

Since clojure is unlikely to change here and EDN implementations in the wild seem to end up following clojure instead of this spec, it seems to be best to bring the spec in line with the clojure implementation.

    $ clojure
    Clojure 1.9.0
    user=> 1.
    1.0
