### PR TITLE
Add deffinition for digits in the integer bnf

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ valid integer not distinct from 0.
       + 1-9 digits
       - digit
       - 1-9 digits
+    digits
+      digit
+      digit digits
 
 ### floating point numbers
 


### PR DESCRIPTION
Because the floating point numbers bfn has it,
integers should too.